### PR TITLE
Fix login issue: Internet Explorer engine is not available

### DIFF
--- a/Super-admin-Remover/Unifi_Super_Admin_remover.ps1
+++ b/Super-admin-Remover/Unifi_Super_Admin_remover.ps1
@@ -123,7 +123,7 @@ function login {
         $CheckBox_ignoressl.Enabled = $false
     }
     try {
-        $request = Invoke-webrequest -Uri "$script:baseurl/api/login" -method post -body ($script:credential|ConvertTo-Json) -ContentType "application/json; charset=utf-8" -SessionVariable script:myWebSession
+        $request = Invoke-webrequest -Uri "$script:baseurl/api/login" -UseBasicParsing -method post -body ($script:credential|ConvertTo-Json) -ContentType "application/json; charset=utf-8" -SessionVariable script:myWebSession
         if($request.StatusCode -eq 200) {
                 $self_request = Invoke-restmethod -Uri "$baseurl/api/self" -WebSession $myWebSession -ContentType "application/json; charset=utf-8"
                 $self = $self_request.data | where {$_.is_super -eq 'True'}


### PR DESCRIPTION
The issue when login on Windows 10, full message:

> The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.

![image](https://user-images.githubusercontent.com/75596049/176371213-61cfb9e6-145e-4f67-af1f-2db32a0a3e1b.png)
